### PR TITLE
Use _WIN32 instead of __WIN32__ to detect Windows platform

### DIFF
--- a/windows.cpp
+++ b/windows.cpp
@@ -12,7 +12,7 @@
 #include <sys/stat.h>
 using namespace std;
 
-#ifdef __WIN32__
+#ifdef _WIN32
 int bake::scandir (char *directory, struct dirent*** dir_list, char* blank,
              int (*sort)(const struct dirent **, const struct dirent **)) {
     vector <struct dirent> info;

--- a/windows.hpp
+++ b/windows.hpp
@@ -9,7 +9,7 @@
 #ifndef BAKE_WINDOWS_H
 #define BAKE_WINDOWS_H
 
-#ifdef __WIN32__
+#ifdef _WIN32
 
 #include <windows.h>
 #include <string>


### PR DESCRIPTION
`_WIN32` is the preferred constant to detect Windows platform (used on MinGW and MSVC). Also bake is already using it [here](https://github.com/felipetavares/bake/blob/master/sundown/autolink.c#L25) and [here](https://github.com/felipetavares/bake/blob/master/sundown/markdown.c#L28).
