### PR TITLE
Avoid copying Template instances

### DIFF
--- a/bake.cpp
+++ b/bake.cpp
@@ -345,7 +345,7 @@ int main (int argc, char **argv) {
 		cout << "bake: locale: " << setlocale(LC_ALL, NULL) << endl;
 	}
 
-	auto reader = Template(conf.get("template"));
+	Template reader(conf.get("template"));
 	auto temp = reader.read();
 
 	Template *post_template_reader;

--- a/template.hpp
+++ b/template.hpp
@@ -89,6 +89,10 @@ private:
   void process(char);
   void move_state(unsigned int);
   void next_state(unsigned int);
+
+  // Avoid copying
+  Template(const Template&);
+  Template& operator=(const Template&);
 };
 
 }


### PR DESCRIPTION
Template class uses a raw pointer to a Tree, so we cannot copy instances
of this class if we don't define our custom copy constructor or operator=.

This commit fixes a crash when compiling with MSVC. (I'm pretty sure the
crash should happen in a random fashion in other platforms.)
